### PR TITLE
Adding a OTP to be required for transfer to be processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ NewBank is a Java application. This document details the protocol for interactin
 | `NEWACCOUNT <Name>` | Description: Creates a new account. Returns `SUCCESS` or `FAIL` | Example: `NEWACCOUNT Savings`
 | `SHOWTRANSACTIONS` | Description: List all transactions |
 | `MOVE <Amount> <From> <To>` | Description: moves money from one account to another. Returns `SUCCESS` or `FAIL` | Example: `MOVE 100 Main Savings` 
-| `PAY <Person/Company> <Ammount>` | Description: Pay a person amount of money. Returns `SUCCESS` or `FAIL`. | Example: `PAY John 100`
+| `PAY <Person/Company> <Ammount>` | Description: Pay a person amount of money. Will create a transfer for the transaction that then need to be approved, on success the OTP for approving the transfer will be printed in the server console. | Example: `PAY John 100`
 | `NEWPASSWORD <OldPassword> <NewPassword>` | Description: Sets a new password. To set a new password the user has to provide the old password. | Example: `NEWPASSWORD secretWord newSecretWord`
+| `SHOWPENDING`| Description: Customers can see their pending transfers. 
+| `APPROVE <transactionId> <OTP>` | Description: Approves and performs the transfer, when given the correct OTP. Only the customer of the 'from' account can approve a tranfer. | Example: `APPROVE 1 1234`
 | `LOGOUT` | Description: Logout the customer. |
 
 

--- a/server/src/main/java/uk/ac/bath/newbank/NewBankClientHandler.java
+++ b/server/src/main/java/uk/ac/bath/newbank/NewBankClientHandler.java
@@ -58,10 +58,16 @@ public class NewBankClientHandler extends Thread {
                 "\t \t PAY <AccountFrom> <Customer> <AccountNumber> <Amount>"
                     + "\t\t\t:::From Customer's Selected account to  Recipient's account by AccountNumber ");
 
-            out.println("4. Show Transactions");
+            out.println("4. Show Pending Transfers");
+            out.println("\t Usage: SHOWPENDING");
+
+            out.println("5. Approve Pending Transfer");
+            out.println("\t Usage: APPROVE <TransferID> <OneTimePin>");
+
+            out.println("6. Show Transactions");
             out.println("\t Usage: SHOWTRANSACTIONS");
 
-            out.println("5. Move Money ");
+            out.println("7. Move Money ");
             out.println("\t Usage: MOVE <Amount> <From> <To>");
 
           } else if (user instanceof Banker) {

--- a/server/src/main/java/uk/ac/bath/newbank/database/TransactionDB.java
+++ b/server/src/main/java/uk/ac/bath/newbank/database/TransactionDB.java
@@ -24,6 +24,15 @@ public class TransactionDB {
     return instance;
   }
 
+  public Transaction getTransactionById(long transactionId) {
+    for (Transaction t : this.transactions) {
+      if (t.getTransactionId() == transactionId) {
+        return t;
+      }
+    }
+    return null;
+  }
+
   public void addTransaction(Transaction transaction) {
     transactionId++;
     transaction.setTransactionId(transactionId);

--- a/server/src/main/java/uk/ac/bath/newbank/model/Account.java
+++ b/server/src/main/java/uk/ac/bath/newbank/model/Account.java
@@ -134,6 +134,8 @@ public class Account {
                 + transaction.getToAccount().getCustomer().getUserID()
                 + "\t| Account Number: "
                 + transaction.getToAccount().getAccountNumber()
+                + "\t| Status: "
+                + transaction.getStatus()
                 + "\t|\t "
                 + "\n";
       } else if (transaction.getToAccount() == this
@@ -152,6 +154,8 @@ public class Account {
                 + transaction.getFromAccount().getCustomer().getUserID()
                 + "\t| Account Number: "
                 + transaction.getFromAccount().getAccountNumber()
+                + "\t| Status: "
+                + transaction.getStatus()
                 + "\t|\t "
                 + "\n";
       } else if (transaction.getToAccount().getCustomer()
@@ -175,6 +179,8 @@ public class Account {
                 + "("
                 + transaction.getToAccount().getAccountNumber()
                 + ")"
+                + "\t| Status: "
+                + transaction.getStatus()
                 + "\t|\t "
                 + "\n";
       }
@@ -188,6 +194,27 @@ public class Account {
 
     if (!transactions.isEmpty()) {
       s = this.printTransaction(transactions);
+    } else {
+      s = "No Transactions found for this account";
+    }
+    return s;
+  }
+
+  public String showPendingTransactions() {
+    String s = "";
+    List<Transaction> transactions = transactionDB.getTransactionsByAccount(this);
+
+    if (!transactions.isEmpty()) {
+      for (Transaction t : transactions) {
+        if (t.getStatus() == Transaction.Status.COMPLETE) {
+          transactions.remove(t);
+        }
+      }
+      if (transactions.isEmpty()) {
+        s = "No pending transactions for this account.";
+      } else {
+        s = this.printTransaction(transactions);
+      }
     } else {
       s = "No Transactions found for this account";
     }

--- a/server/src/main/java/uk/ac/bath/newbank/model/Transaction.java
+++ b/server/src/main/java/uk/ac/bath/newbank/model/Transaction.java
@@ -3,19 +3,29 @@ package uk.ac.bath.newbank.model;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Random;
 
 public class Transaction {
+  public enum Status {
+    PENDING,
+    COMPLETE
+  }
+
   private long transactionId;
   private long time;
   private Account fromAccount;
   private Account toAccount;
   private double amount;
+  private Status status;
+  private String OTP;
 
   public Transaction(Account fromAccount, Account toAccount, double amount) {
     this.fromAccount = fromAccount;
     this.toAccount = toAccount;
     this.amount = amount;
     this.time = Instant.now().toEpochMilli();
+    this.status = Status.PENDING;
+    this.OTP = generateOTP();
   }
 
   public String getTimeString() {
@@ -55,7 +65,9 @@ public class Transaction {
         + "\t|\t "
         + toAccount.getAccountName()
         + "\t|\t "
-        + amount);
+        + amount
+        + "\t|\t "
+        + status);
   }
 
   public long getTransactionId() {
@@ -72,5 +84,23 @@ public class Transaction {
 
   public void setAmount(double amount) {
     this.amount = amount;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public void setCompleteStatus() {
+    this.time = Instant.now().toEpochMilli();
+    this.status = Status.COMPLETE;
+  }
+
+  public String getOTP() {
+    return OTP;
+  }
+
+  public String generateOTP() {
+    Random rand = new Random();
+    return String.format("%04d", rand.nextInt(10000));
   }
 }

--- a/server/src/main/java/uk/ac/bath/newbank/model/roles/Customer.java
+++ b/server/src/main/java/uk/ac/bath/newbank/model/roles/Customer.java
@@ -52,6 +52,8 @@ public class Customer extends User {
                 + transaction.getToAccount().getCustomer().getUserID()
                 + "\t| Account Number: "
                 + transaction.getToAccount().getAccountNumber()
+                + "\t| Status: "
+                + transaction.getStatus()
                 + "\t|\t "
                 + "\n";
       } else if (transaction.getToAccount().getCustomer() == this
@@ -70,6 +72,8 @@ public class Customer extends User {
                 + transaction.getFromAccount().getCustomer().getUserID()
                 + "\t| Account Number: "
                 + transaction.getFromAccount().getAccountNumber()
+                + "\t| Status: "
+                + transaction.getStatus()
                 + "\t|\t "
                 + "\n";
       } else if (transaction.getToAccount().getCustomer()
@@ -93,6 +97,8 @@ public class Customer extends User {
                 + "("
                 + transaction.getToAccount().getAccountNumber()
                 + ")"
+                + "\t| Status: "
+                + transaction.getStatus()
                 + "\t|\t "
                 + "\n";
       }
@@ -105,6 +111,22 @@ public class Customer extends User {
     List<Transaction> transactions = transactionDB.getTransactionsByCustomer(this);
 
     s = this.printTransaction(transactions);
+    return s;
+  }
+
+  public String showPendingTransactions() {
+    String s = "";
+    List<Transaction> transactions = transactionDB.getTransactionsByCustomer(this);
+    for (Transaction t : transactions) {
+      if (t.getStatus() == Transaction.Status.COMPLETE) {
+        transactions.remove(t);
+      }
+    }
+    if (transactions.isEmpty()) {
+      s = "No pending transactions.";
+    } else {
+      s = this.printTransaction(transactions);
+    }
     return s;
   }
 


### PR DESCRIPTION
When customers use the PAY feature to transfer money this now creates a transaction with the status pending but does not move the money. A One Time Pin is created for the transaction and printed in the server console. Pending transaction can be seen using SHOWPENDING. Customers must then use the APPROVE function where they give the transaction ID and the OTP to trigger the transfer to happen. Only the customer that own the 'from' account is able to approve a transaction. The transaction status is changed to complete and it will no long appear in SHOWPENDING.